### PR TITLE
Add Lifecycle.doOnEvent.

### DIFF
--- a/lifecycle/src/main/java/com/crazylegend/lifecycle/LifecycleExtensions.kt
+++ b/lifecycle/src/main/java/com/crazylegend/lifecycle/LifecycleExtensions.kt
@@ -1,9 +1,13 @@
 package com.crazylegend.lifecycle
 
-import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.*
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -59,4 +63,16 @@ fun AppCompatActivity.repeatingJobOnStarted(block: suspend CoroutineScope.() -> 
 
 fun AppCompatActivity.repeatingJobOnResumed(block: suspend CoroutineScope.() -> Unit) {
     lifecycleScope.launch { repeatOnLifecycle(Lifecycle.State.RESUMED, block) }
+}
+
+fun Lifecycle.doOnEvent(which: Lifecycle.Event, block: () -> Unit) {
+    val observer = object : LifecycleEventObserver {
+        override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+            if (which != event) return
+            removeObserver(this)
+            block()
+        }
+    }
+
+    addObserver(observer)
 }


### PR DESCRIPTION
This is a one-shot callback for work that needs to be done in a
specific lifecycle state.

Use case I had for this was waiting for an app to be in a started
state before performing a Fragment transaction.

For example:
```
// In Activity.onCreate()
viewModel.events() // SharedFlow
    .onEach { event ->
       if (event is Event.FragmentNavigate) {
           // User might have backgrounded the app at this point, so
           // wait til it's safe to navigate.
           lifecycle.doOnEvent(Lifecycle.Event.ON_START) {
               supportFragmentManager.commit {
                   replace(android.R.id.content, MyFragment()
               }
           }
       }
    }
    .launchIn(lifecycleScope)
```

There exists Lifecycle.whenStarted which can achieve the same as the above,
but it needlessly launches a coroutine, and the API is documented that it'll
be removed entirely in a future update.
See: https://developer.android.com/reference/kotlin/androidx/lifecycle/LifecycleCoroutineScope#launchwhenstarted